### PR TITLE
Fixing bad default FIELD_TEMPLATE that creates invalid nodes in IE 7-8 with YUI 3.4.1

### DIFF
--- a/src/gallery-form/js/form-field.js
+++ b/src/gallery-form/js/form-field.js
@@ -16,7 +16,7 @@ Y.FormField = Y.Base.create('form-field', Y.Widget, [Y.WidgetParent, Y.WidgetChi
      * @type String
      * @description Template used to render the field node
      */
-    FIELD_TEMPLATE : '<input></input>',
+    FIELD_TEMPLATE : '<input>',
 
     /**
      * @property FormField.FIELD_CLASS


### PR DESCRIPTION
In YUI 3.4.1, if you execute `Y.Node.create('<input></input>');`, you are not returned an input element in IE 7 or 8. You are returned a document fragment instead which does not have a `setAttribute` function on it which causes `_syncDisabled` to break.

Change it to `Y.Node.create('<input>');` and you get what you want.

Temporary fix: Before you render your Form, make sure to `Y.FormField.prototype.FIELD_TEMPLATE = '<input>';`
